### PR TITLE
smaller banner height

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -3,7 +3,7 @@
 	background-size: cover;
 	background-position: bottom;
 	padding: 10px 0;
-	height: 600px;
+	height: 440px;
 }
 
 .banner h1 {

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2020_11_19_172833) do
+ActiveRecord::Schema.define(version: 2020_11_19_173356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
WHAT
Banner has smaller height now. 

WHY
So we can see there are cards below the banner before we filter using our search